### PR TITLE
Add new interactive visual demos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
             "dependencies": {
                 "@react-three/drei": "^10.0.3",
                 "@react-three/fiber": "^9.0.4",
+                "@react-three/postprocessing": "^3.0.4",
+                "postprocessing": "^6.37.6",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
                 "three": "^0.174.0"
@@ -856,6 +858,32 @@
                 }
             }
         },
+        "node_modules/@react-three/postprocessing": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@react-three/postprocessing/-/postprocessing-3.0.4.tgz",
+            "integrity": "sha512-e4+F5xtudDYvhxx3y0NtWXpZbwvQ0x1zdOXWTbXMK6fFLVDd4qucN90YaaStanZGS4Bd5siQm0lGL/5ogf8iDQ==",
+            "license": "MIT",
+            "dependencies": {
+                "maath": "^0.6.0",
+                "n8ao": "^1.9.4",
+                "postprocessing": "^6.36.6"
+            },
+            "peerDependencies": {
+                "@react-three/fiber": "^9.0.0",
+                "react": "^19.0",
+                "three": ">= 0.156.0"
+            }
+        },
+        "node_modules/@react-three/postprocessing/node_modules/maath": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/maath/-/maath-0.6.0.tgz",
+            "integrity": "sha512-dSb2xQuP7vDnaYqfoKzlApeRcR2xtN8/f7WV/TMAkBC8552TwTLtOO0JTcSygkYMjNDPoo6V01jTw/aPi4JrMw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/three": ">=0.144.0",
+                "three": ">=0.144.0"
+            }
+        },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1446,6 +1474,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/n8ao": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/n8ao/-/n8ao-1.10.1.tgz",
+            "integrity": "sha512-hhI1pC+BfOZBV1KMwynBrVlIm8wqLxj/abAWhF2nZ0qQKyzTSQa1QtLVS2veRiuoBQXojxobcnp0oe+PUoxf/w==",
+            "license": "ISC",
+            "peerDependencies": {
+                "postprocessing": ">=6.30.0",
+                "three": ">=0.137"
+            }
+        },
         "node_modules/nanoid": {
             "version": "3.3.8",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
@@ -1515,6 +1553,15 @@
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/postprocessing": {
+            "version": "6.37.6",
+            "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.37.6.tgz",
+            "integrity": "sha512-KrdKLf1257RkoIk3z3nhRS0aToKrX2xJgtR0lbnOQUjd+1I4GVNv1gQYsQlfRglvEXjpzrwqOA5fXfoDBimadg==",
+            "license": "Zlib",
+            "peerDependencies": {
+                "three": ">= 0.157.0 < 0.179.0"
             }
         },
         "node_modules/potpack": {

--- a/package.json
+++ b/package.json
@@ -4,23 +4,25 @@
     "version": "0.1.0",
     "type": "module",
     "scripts": {
-      "dev": "vite",
-      "build": "tsc && vite build",
-      "preview": "vite preview"
+        "dev": "vite",
+        "build": "tsc && vite build",
+        "preview": "vite preview"
     },
     "dependencies": {
-      "@react-three/fiber": "^9.0.4",
-      "@react-three/drei": "^10.0.3",
-      "react": "^19.0.0",
-      "react-dom": "^19.0.0",
-      "three": "^0.174.0"
+        "@react-three/drei": "^10.0.3",
+        "@react-three/fiber": "^9.0.4",
+        "@react-three/postprocessing": "^3.0.4",
+        "postprocessing": "^6.37.6",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "three": "^0.174.0"
     },
     "devDependencies": {
-      "@types/react": "^18.2.15",
-      "@types/react-dom": "^18.2.7",
-      "@types/three": "^0.158.3",
-      "@vitejs/plugin-react": "^4.0.3",
-      "typescript": "^5.0.2",
-      "vite": "^4.4.5"
+        "@types/react": "^18.2.15",
+        "@types/react-dom": "^18.2.7",
+        "@types/three": "^0.158.3",
+        "@vitejs/plugin-react": "^4.0.3",
+        "typescript": "^5.0.2",
+        "vite": "^4.4.5"
     }
-  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,9 @@ import Controls from './components/Controls/Controls';
 import DebugInfo from './components/DebugInfo/DebugInfo';
 import Gyroscope from './components/Gyroscope/Gyroscope';
 import PinkSphereSection from './components/PinkSphere/PinkSphereSection';
+import SurferSection from './components/SurferSection/SurferSection';
+import AudioVisualizerSection from './components/AudioVisualizer/AudioVisualizer';
+import DigitalRain from './components/DigitalRain/DigitalRain';
 import './styles/global.css';
 import PageSection from './components/PageSection/PageSection';
 import CubeScene from './components/ThreeCube/CubeScene';
@@ -37,9 +40,14 @@ const AppContent = () => {
       
       {/* New Pink Sphere Section */}
       <PinkSphereSection />
-      
+
       <PageSection bgStyle='crazy'>
         <InsetCard style={{ transform: physics.transforms.insetCard }} />
+      </PageSection>
+
+      <PageSection bgStyle='digitalrain' bgEl={currentTheme === 'matrix' ? <DigitalRain /> : null}>
+        <h1>Digital Rain</h1>
+        <p>A tribute to streaming code and endless data.</p>
       </PageSection>
 
       <PageSection bgStyle='patterned'>
@@ -48,17 +56,13 @@ const AppContent = () => {
           <p>Notice how the tab bar responds to your scrolling with inertia and natural physics.</p>
       </PageSection>
 
-      <PageSection bgStyle='colorful'>
-          <h1>Scroll Down</h1>
-          <p>This demo uses scroll velocity to drive a pendulum physics simulation, creating a natural-feeling animation for the floating tab bar.</p>
-          <p>Notice how the tab bar responds to your scrolling with inertia and natural physics.</p>
+      <PageSection bgStyle='plain'>
+        <Terminal3D />
       </PageSection>
-      
-      {/* Placeholder sections */}
-      <section className="section">
-        <div className="content">
-        </div>
-      </section>
+
+      <SurferSection />
+
+      <AudioVisualizerSection />
       
       <Gyroscope 
         enabled={gyroscope.gyroState.enabled}

--- a/src/components/AudioVisualizer/AudioVisualizer.css
+++ b/src/components/AudioVisualizer/AudioVisualizer.css
@@ -1,0 +1,14 @@
+.audio-section {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: radial-gradient(circle at center, #111, #000);
+}
+
+.audio-canvas {
+  width: 80%;
+  height: 200px;
+  background: #000;
+}

--- a/src/components/AudioVisualizer/AudioVisualizer.tsx
+++ b/src/components/AudioVisualizer/AudioVisualizer.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+import './AudioVisualizer.css';
+
+const AudioVisualizer = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    let animationId: number;
+    let analyser: AnalyserNode;
+    let dataArray: Uint8Array;
+
+    navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
+      const audioCtx = new (window.AudioContext || (window as any).webkitAudioContext)();
+      analyser = audioCtx.createAnalyser();
+      const source = audioCtx.createMediaStreamSource(stream);
+      source.connect(analyser);
+      analyser.fftSize = 64;
+      const bufferLength = analyser.frequencyBinCount;
+      dataArray = new Uint8Array(bufferLength);
+
+      const draw = () => {
+        animationId = requestAnimationFrame(draw);
+        analyser.getByteFrequencyData(dataArray);
+        ctx.clearRect(0,0,canvas.width,canvas.height);
+        const barWidth = canvas.width / bufferLength;
+        dataArray.forEach((v,i) => {
+          const barHeight = v / 255 * canvas.height;
+          ctx.fillStyle = `hsl(${(i/bufferLength)*360},80%,50%)`;
+          ctx.fillRect(i*barWidth, canvas.height - barHeight, barWidth-2, barHeight);
+        });
+      };
+      draw();
+    }).catch(err => {
+      console.error(err);
+    });
+
+    const handleResize = () => {
+      canvas.width = canvas.offsetWidth;
+      canvas.height = canvas.offsetHeight;
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      cancelAnimationFrame(animationId);
+    };
+  }, []);
+
+  return <canvas className="audio-canvas" ref={canvasRef} />;
+};
+
+const AudioVisualizerSection = () => (
+  <section className="audio-section">
+    <h1>Microphone Visualizer</h1>
+    <AudioVisualizer />
+  </section>
+);
+
+export default AudioVisualizerSection;

--- a/src/components/DigitalRain/DigitalRain.css
+++ b/src/components/DigitalRain/DigitalRain.css
@@ -1,0 +1,9 @@
+.digital-rain {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  pointer-events: none;
+}

--- a/src/components/DigitalRain/DigitalRain.tsx
+++ b/src/components/DigitalRain/DigitalRain.tsx
@@ -1,0 +1,57 @@
+import { useRef, useEffect } from 'react';
+import './DigitalRain.css';
+
+const DigitalRain = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    let width = canvas.offsetWidth;
+    let height = canvas.offsetHeight;
+    canvas.width = width;
+    canvas.height = height;
+
+    const fontSize = 16;
+    const columns = Math.floor(width / fontSize);
+    const drops = Array.from({ length: columns }, () => Math.random() * height / fontSize);
+
+    const draw = () => {
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.05)';
+      ctx.fillRect(0, 0, width, height);
+      ctx.fillStyle = '#0f0';
+      ctx.font = `${fontSize}px monospace`;
+
+      for (let i = 0; i < drops.length; i++) {
+        const text = Math.random() > 0.5 ? '0' : '1';
+        ctx.fillText(text, i * fontSize, drops[i] * fontSize);
+        if (drops[i] * fontSize > height && Math.random() > 0.975) {
+          drops[i] = 0;
+        }
+        drops[i] += 0.9;
+      }
+      animationFrameId = requestAnimationFrame(draw);
+    };
+
+    let animationFrameId = requestAnimationFrame(draw);
+
+    const handleResize = () => {
+      width = canvas.offsetWidth;
+      height = canvas.offsetHeight;
+      canvas.width = width;
+      canvas.height = height;
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="digital-rain" />;
+};
+
+export default DigitalRain;

--- a/src/components/PageSection/PageSection.css
+++ b/src/components/PageSection/PageSection.css
@@ -72,6 +72,15 @@
   background: linear-gradient(45deg, #050d16 0%, #1e88e5 100%);
 }
 
+/* DIGITAL RAIN BACKGROUND */
+.bg-digitalrain {
+  position: relative;
+  overflow: hidden;
+}
+.bg-digitalrain.theme-matrix {
+  background-color: #000800;
+}
+
 /* PATTERNED BACKGROUNDS */
 .bg-patterned.theme-default {
   background-color: var(--darker);

--- a/src/components/PageSection/PageSection.tsx
+++ b/src/components/PageSection/PageSection.tsx
@@ -2,7 +2,13 @@ import { ReactNode, CSSProperties, useEffect } from 'react';
 import { useTheme } from '../../contexts/ThemeContext';
 import './PageSection.css';
 
-export type BgStyle = 'plain' | 'colorful' | 'patterned' | 'animated' | 'crazy';
+export type BgStyle =
+  | 'plain'
+  | 'colorful'
+  | 'patterned'
+  | 'animated'
+  | 'crazy'
+  | 'digitalrain';
 
 interface PageSectionProps {
   children: ReactNode;

--- a/src/components/SurferSection/SurferSection.css
+++ b/src/components/SurferSection/SurferSection.css
@@ -1,0 +1,11 @@
+.surfer-section {
+  height: 100vh;
+  width: 100%;
+  background: radial-gradient(circle at center, #001, #000);
+  position: relative;
+}
+
+.surfer-canvas {
+  width: 100%;
+  height: 100%;
+}

--- a/src/components/SurferSection/SurferSection.tsx
+++ b/src/components/SurferSection/SurferSection.tsx
@@ -1,0 +1,20 @@
+import { Canvas } from '@react-three/fiber';
+import { Suspense } from 'react';
+import VibeSurfer from '../ThreeCube/VibeSurfer';
+import './SurferSection.css';
+
+const SurferSection = () => {
+  return (
+    <section className="surfer-section">
+      <Canvas camera={{ position: [0, 1.5, 5], fov: 60 }} className="surfer-canvas">
+        <ambientLight intensity={0.6} />
+        <pointLight position={[2, 3, 2]} />
+        <Suspense fallback={null}>
+          <VibeSurfer />
+        </Suspense>
+      </Canvas>
+    </section>
+  );
+};
+
+export default SurferSection;

--- a/src/components/Terminal3D/Terminal3D.tsx
+++ b/src/components/Terminal3D/Terminal3D.tsx
@@ -14,7 +14,7 @@ const Terminal3D = ({ style }: Terminal3DProps) => {
   
   // Typewriter effect
   useEffect(() => {
-    const fullText = "Welcome to AI Doodle #0. This page is made using Claude 3.7 on a mobile phone without writing a single line of code myself!";
+    const fullText = "Welcome to AI Doodle #0. This page was created with a bit of generative sorcery and some clever code.";
     let index = 0;
     const timer = setInterval(() => {
       setText(fullText.substring(0, index));
@@ -36,9 +36,9 @@ const Terminal3D = ({ style }: Terminal3DProps) => {
   
   return (
     <section className="terminal3d-section">
-      <CubeScene>
-        <div className="terminal3d-container">
-          <div className="terminal3d-window terminal-scan-effect" style={style}>
+      <CubeScene />
+      <div className="terminal3d-container">
+        <div className="terminal3d-window terminal-scan-effect" style={style}>
             <div className="terminal-header">
               <div className="terminal-dots">
                 <div className="terminal-dot"></div>
@@ -68,8 +68,7 @@ const Terminal3D = ({ style }: Terminal3DProps) => {
             </div>
           </div>
         </div>
-      </CubeScene>
-    </section>
+      </section>
   );
 };
 

--- a/src/components/TerminalBanner/TerminalBanner.tsx
+++ b/src/components/TerminalBanner/TerminalBanner.tsx
@@ -34,7 +34,7 @@ const TerminalBanner = ({ style }: TerminalBannerProps) => {
         </div>
         <div style={{ marginTop: '5px' }}>
           <span className="terminal-prompt">[INFO]</span>
-          <span className="terminal-text">This page is made using Claude 3.7 on a mobile phone without writing a single line of code myself!</span>
+          <span className="terminal-text">This playground was crafted with a dash of AI-assisted creativity.</span>
         </div>
         <div style={{ marginTop: '20px' }}>
           <span className="terminal-prompt">$</span>

--- a/src/components/ThreeCube/CubeScene.tsx
+++ b/src/components/ThreeCube/CubeScene.tsx
@@ -2,7 +2,7 @@ import React, { Suspense, useMemo, useRef } from 'react'
 import { Canvas, useFrame } from '@react-three/fiber'
 import { EffectComposer, Noise, Vignette } from '@react-three/postprocessing'
 import { BlendFunction } from 'postprocessing'
-import { Mesh } from 'three'
+import { Mesh, HalfFloatType } from 'three'
 
 interface CubeProps {
   position?: [number, number, number];
@@ -76,20 +76,20 @@ export const CubeScene: React.FC<CubeSceneProps> = ({
         <EffectComposer 
           enabled 
           multisampling={0} // Disable multisampling for performance
-          frameBufferType={16} // Use HALF_FLOAT buffer type for better performance
+          frameBufferType={HalfFloatType} // Use HALF_FLOAT buffer type for better performance
         >
           <Noise 
             opacity={noiseIntensity} 
             blendFunction={noiseBlendFunction}
             premultiply // Optimize blend operation
           />
-          {vignetteEnabled && (
+          {vignetteEnabled ? (
             <Vignette
               offset={0.3}
               darkness={0.7}
               blendFunction={BlendFunction.NORMAL}
             />
-          )}
+          ) : null}
         </EffectComposer>
       </Suspense>
     </Canvas>

--- a/src/components/ThreeCube/VibeSurfer.tsx
+++ b/src/components/ThreeCube/VibeSurfer.tsx
@@ -61,9 +61,9 @@ const cyberWaveShader = {
 };
 
 const VibeSurfer = () => {
-  const waveRef = useRef();
-  const shaderRef = useRef();
-  const surferRef = useRef();
+  const waveRef = useRef<THREE.Mesh>(null!);
+  const shaderRef = useRef<THREE.ShaderMaterial>(null!);
+  const surferRef = useRef<THREE.Group>(null!);
   
   // Create shader material
   const waveMaterial = new THREE.ShaderMaterial(cyberWaveShader);

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -17,12 +17,17 @@ body.theme-vaporwave {
       linear-gradient(-45deg, transparent 75%, rgba(0, 255, 255, 0.1) 75%);
     background-size: 40px 40px;
     background-position: 0 0, 0 20px, 20px -20px, -20px 0px;
+    animation: vaporwaveBG 30s linear infinite;
   }
   
   body.theme-vaporwave h1 {
     font-family: 'Press Start 2P', cursive;
     letter-spacing: 2px;
     text-shadow: 4px 4px 0px #00ffff, -4px -4px 0px #ff00ff;
+  }
+
+  body.theme-vaporwave p {
+    color: #ffccff;
   }
   
   body.theme-vaporwave .section::before {
@@ -40,7 +45,7 @@ body.theme-vaporwave {
   }
   
   /* Matrix Theme */
-  body.theme-matrix {
+body.theme-matrix {
     --primary: #00ff00;
     --secondary: #33ff33;
     --dark: #001100;
@@ -52,6 +57,7 @@ body.theme-vaporwave {
     --terminal-fg: #00ff00;
     font-family: 'Source Code Pro', 'Courier New', monospace;
     background-image: url("data:image/svg+xml,%3Csvg width='40' height='80' xmlns='http://www.w3.org/2000/svg'%3E%3Ctext x='50%25' y='10' font-family='monospace' font-size='10' fill='rgba(0,255,0,0.15)' text-anchor='middle'%3E1%3C/text%3E%3Ctext x='50%25' y='20' font-family='monospace' font-size='10' fill='rgba(0,255,0,0.15)' text-anchor='middle'%3E0%3C/text%3E%3Ctext x='50%25' y='30' font-family='monospace' font-size='10' fill='rgba(0,255,0,0.15)' text-anchor='middle'%3E1%3C/text%3E%3Ctext x='50%25' y='40' font-family='monospace' font-size='10' fill='rgba(0,255,0,0.15)' text-anchor='middle'%3E0%3C/text%3E%3Ctext x='50%25' y='50' font-family='monospace' font-size='10' fill='rgba(0,255,0,0.15)' text-anchor='middle'%3E1%3C/text%3E%3Ctext x='50%25' y='60' font-family='monospace' font-size='10' fill='rgba(0,255,0,0.15)' text-anchor='middle'%3E0%3C/text%3E%3Ctext x='50%25' y='70' font-family='monospace' font-size='10' fill='rgba(0,255,0,0.15)' text-anchor='middle'%3E1%3C/text%3E%3Ctext x='50%25' y='80' font-family='monospace' font-size='10' fill='rgba(0,255,0,0.15)' text-anchor='middle'%3E0%3C/text%3E%3C/svg%3E");
+    animation: matrixBG 60s linear infinite;
   }
   
   body.theme-matrix h1 {
@@ -79,10 +85,12 @@ body.theme-vaporwave {
   body.theme-matrix p {
     font-family: 'VT323', monospace;
     letter-spacing: 0.5px;
+    color: #80ff80;
+    text-shadow: 0 0 5px #00ff00;
   }
   
   /* Light Theme */
-  body.theme-light {
+body.theme-light {
     --primary: #3498db;
     --secondary: #2980b9;
     --dark: #f5f5f5;
@@ -98,6 +106,7 @@ body.theme-vaporwave {
       radial-gradient(circle at 0% 50%, transparent 20%, rgba(52, 152, 219, 0.03) 21%, rgba(52, 152, 219, 0.03) 34%, transparent 35%, transparent);
     background-size: 50px 50px;
     background-position: 0 0;
+    animation: lightBG 40s linear infinite;
   }
   
   body.theme-light h1 {
@@ -126,10 +135,11 @@ body.theme-vaporwave {
   
   body.theme-light p {
     color: #555;
+    text-shadow: 0 1px 0 #fff;
   }
   
   /* Midnight Blue Theme */
-  body.theme-midnight {
+body.theme-midnight {
     --primary: #1e88e5;
     --secondary: #0d47a1;
     --dark: #0a1929;
@@ -145,6 +155,7 @@ body.theme-vaporwave {
       radial-gradient(circle, rgba(255, 152, 0, 0.05) 1px, transparent 1px);
     background-size: 30px 30px, 40px 40px;
     background-position: 0 0, 15px 15px;
+    animation: midnightBG 60s linear infinite;
   }
   
   body.theme-midnight h1 {
@@ -169,3 +180,27 @@ body.theme-vaporwave {
   body.theme-midnight .section:nth-child(even) {
     background-color: #0e2133;
   }
+
+  body.theme-midnight p {
+    color: #90caf9;
+  }
+
+@keyframes vaporwaveBG {
+  0% { background-position: 0 0, 0 20px, 20px -20px, -20px 0; }
+  100% { background-position: 40px 40px, 40px 60px, 60px 20px, 20px 40px; }
+}
+
+@keyframes matrixBG {
+  0% { background-position: 0 0; }
+  100% { background-position: 0 80px; }
+}
+
+@keyframes lightBG {
+  0% { background-position: 0 0; }
+  100% { background-position: 50px 50px; }
+}
+
+@keyframes midnightBG {
+  0% { background-position: 0 0, 15px 15px; }
+  100% { background-position: -40px -40px, -25px -25px; }
+}


### PR DESCRIPTION
## Summary
- modernize intro banner text
- implement animated Matrix digital rain and integrate it into the demo page
- add new Surfer, Audio visualizer and 3D terminal sections
- enhance theme animations and digital rain background
- general tweaks to theme styles

## Testing
- `npx vite build`

------
https://chatgpt.com/codex/tasks/task_e_6878a64e2dcc8330a6b218f9edd395f6